### PR TITLE
no more dependency hell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,5 +4,18 @@ pkgs.mkShell rec {
     pkg-config
     dbus
     udev
+    wayland
+    seatd
+    libinput
+    libxkbcommon
+    xgboost
+    cairo
+    libdrm
+    gdk-pixbuf
+    wayland-scanner
+    pango
+    wlroots
+    wayland-protocols
+    mesa
   ];
 }


### PR DESCRIPTION
Before this fix was pushed, cargo would complain about missing libraries for nixOS users(me)
so now no more library hell :D